### PR TITLE
Show fortification button on all attack rolls

### DIFF
--- a/scripts/fortification.js
+++ b/scripts/fortification.js
@@ -79,7 +79,7 @@ Hooks.once('ready', () => {
 
 Hooks.on('createChatMessage', message => {
   const context = message.flags?.pf2e?.context;
-  if (context?.type !== 'attack-roll' || context?.outcome !== 'criticalSuccess') return;
+  if (context?.type !== 'attack-roll') return;
 
   for (const target of context.targets ?? []) {
     const token = canvas.tokens.get(target.tokenId ?? target.token);


### PR DESCRIPTION
## Summary
- run fortification chat listener on every attack roll rather than only critical hits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ed4253b88327a00108ee64e6cddd